### PR TITLE
refactor: use byte arrays instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can run commands through [netcat](https://www.freebsd.org/cgi/man.cgi?nc) fo
 echo -e '*1\r\n$4\r\nPING\r\n' | nc localhost 8001
 ```
 
-Or you can start a redis client using the Redis CLI: `redis-cli -p 8001` and then use it in Interactive mode.
+Or you can start a redis client using the [redis-cli](https://redis.io/topics/rediscli): `redis-cli -p 8001` and then use it in Interactive mode.
 
 ```bash
 127.0.0.1:8001> SET hello 3

--- a/resp/decode.go
+++ b/resp/decode.go
@@ -1,3 +1,5 @@
+//lint:file-ignore ST1008 we want to return error from Decode
+
 // Package resp implements functions for decoding and encoding RESP 3.
 package resp
 
@@ -8,8 +10,8 @@ import (
 )
 
 var (
-	ErrInvalidSyntax = errors.New("invalid syntax")
-	ErrInvalidInput  = errors.New("invalid input")
+	ErrInvalidSyntax = errors.New("ERR invalid syntax")
+	ErrInvalidInput  = errors.New("ERR invalid input")
 )
 
 const (
@@ -133,7 +135,7 @@ func handleBulkError(in []byte) (error, int) {
 	return errors.New(v.(string)), read
 }
 
-func handleArray(in []byte) (interface{}, int) {
+func handleArray(in []byte) ([]interface{}, int) {
 	length, read := readUntilCRLF(in)
 	size, _ := strconv.Atoi((length))
 	switch size {

--- a/store/kv.go
+++ b/store/kv.go
@@ -6,12 +6,12 @@ import (
 )
 
 type Store struct {
-	underlying map[string]string
+	underlying map[string]([]byte)
 }
 
 func New() *Store {
 	kv := Store{
-		underlying: make(map[string]string),
+		underlying: make(map[string]([]byte)),
 	}
 	defaultPath := "dump.trdb"
 	f, err := os.Open(defaultPath)
@@ -29,19 +29,19 @@ func New() *Store {
 	return &kv
 }
 
-func (kv *Store) Set(key, value string) {
-	kv.underlying[key] = value
+func (kv *Store) Set(key []byte, value []byte) {
+	kv.underlying[string(key)] = value
 }
 
-func (kv *Store) Get(key string) (value string, ok bool) {
-	v, ok := kv.underlying[key]
+func (kv *Store) Get(key []byte) (value []byte, ok bool) {
+	v, ok := kv.underlying[string(key)]
 	return v, ok
 }
 
-func (kv *Store) Del(key string) {
-	delete(kv.underlying, key)
+func (kv *Store) Del(key []byte) {
+	delete(kv.underlying, string(key))
 }
 
-func (kv *Store) GetUnderlying() *map[string]string {
+func (kv *Store) GetUnderlying() *map[string]([]byte) {
 	return &kv.underlying
 }


### PR DESCRIPTION
This PR starts using `[][]byte` instead of `interface{}` in the `ExecuteCommand` function. Redis clients only send arrays of bulk strings to the Redis server and thus it's not necessary for the `cmdSeq` parameter to be an interface.

The refactoring has made code more cleaner and removed a lot of unnecessary type conversions and assertions everywhere apart from the ugly piece of code introduced [here](https://github.com/tinfoil-knight/tiny-redis/pull/1/files#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R52-R57) which asserts the `[]byte` type on every element of the parsed array.

```
t := (val).([]interface{})

s := make([][]byte, len(t))
for i, x := range t {
	s[i] = x.([]byte)
}
```

Hopefully, it won't make things too slow.

Tests in the `commands` package were fixed and utilities to convert strings and string slices to bytes and slice of bytes were created to make writing tests easy.


